### PR TITLE
Use pytest instead of py.test per upstream recommendation, #dropthedot

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -89,7 +89,7 @@ recommend using ``virtualenvwrapper`` to setup an isolated virtual environment t
    tests, including testing other Python versions with tox::
    
     $ flake8 mtnlion tests
-    $ python setup.py test or py.test
+    $ python setup.py test or pytest
     $ tox
 
    To get flake8 and tox, just pip install them into your virtualenv.
@@ -125,7 +125,7 @@ Tips
 
 - To run a subset of tests::
 
-    $ py.test tests.test_mtnlion
+    $ pytest tests.test_mtnlion
 
 - To quickly setup ``virtualenvwrapper`` add these to your shell rc file::
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ lint: ## check style with flake8
 	flake8 mtnlion tests
 
 test: ## run tests quickly with the default Python
-	py.test
+	pytest
 
 test-all: ## run tests on every Python version with tox
 	tox

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,6 @@ deps =
 ;     -r{toxinidir}/requirements.txt
 commands =
     pip install -U pip
-    py.test --basetemp={envtmpdir}
+    pytest --basetemp={envtmpdir}
 
 


### PR DESCRIPTION
http://blog.pytest.org/2016/whats-new-in-pytest-30/
https://twitter.com/hashtag/dropthedot